### PR TITLE
Fix invalid escape sequence SyntaxWarnings in utils regexes

### DIFF
--- a/utils/get_subs.py
+++ b/utils/get_subs.py
@@ -102,7 +102,7 @@ class subs:
         temp = list(filter(lambda x: re.search(ipv6, x) ==
                     None or re.search(ipv4, x) != None, yaml_proxies))
         temp = list(filter(lambda x: re.search(
-            "path: /(.*?)\?(.*?)=(.*?)}", x) == None, temp))
+            "path: /(.*?)\\?(.*?)=(.*?)}", x) == None, temp))
 
         temp2 = temp
         temp = []
@@ -223,7 +223,7 @@ class subs:
                                 for (index, cl) in enumerate(clash_content):
                                     try:
                                         if re.search(ipv6, str(cl)) == None or re.search(ipv4, str(cl)) != None:
-                                            if re.search("path: /(.*?)\?(.*?)=(.*?)}", str(cl)) == None:
+                                            if re.search("path: /(.*?)\\?(.*?)=(.*?)}", str(cl)) == None:
                                                 # todo first trying without it
                                                 # # fix name issues and replacing the illegal character with empty string
                                                 # try:
@@ -461,7 +461,7 @@ class subs:
                             for (index, cl) in enumerate(clash_content):
                                 try:
                                     if re.search(ipv6, str(cl)) == None or re.search(ipv4, str(cl)) != None:
-                                        if re.search("path: /(.*?)\?(.*?)=(.*?)}", str(cl)) == None:
+                                        if re.search("path: /(.*?)\\?(.*?)=(.*?)}", str(cl)) == None:
                                             # todo first trying without it
                                             # # fix name issues and replacing the illegal character with empty string
                                             # try:

--- a/utils/list_merge.py
+++ b/utils/list_merge.py
@@ -175,7 +175,7 @@ class sub_merge():
         temp = list(filter(lambda x: re.search(ipv6, x) ==
                     None or re.search(ipv4, x) != None, yaml_proxies))
         temp = list(filter(lambda x: re.search(
-            "path: /(.*?)\?(.*?)=(.*?)}", x) == None, temp))
+            "path: /(.*?)\\?(.*?)=(.*?)}", x) == None, temp))
 
         temp2 = temp
         temp = []
@@ -231,7 +231,7 @@ class sub_merge():
         for index in range(len(raw_list)):
             if raw_list[index]['enabled']:
                 if remote == False:
-                    urls = re.split('\|', raw_list[index]['url'])
+                    urls = re.split('\\|', raw_list[index]['url'])
                 else:
                     urls = raw_list[index]['url']
                 raw_list[index]['url'] = urls

--- a/utils/list_merge_airport.py
+++ b/utils/list_merge_airport.py
@@ -25,7 +25,7 @@ class sub_merge():
         for index in range(len(raw_list)):
             if raw_list[index]['enabled']:
                 if remote == False:
-                    urls = re.split('\|', raw_list[index]['url'])
+                    urls = re.split('\\|', raw_list[index]['url'])
                 else:
                     urls = raw_list[index]['url']
                 raw_list[index]['url'] = urls

--- a/utils/sub_convert.py
+++ b/utils/sub_convert.py
@@ -521,15 +521,15 @@ class sub_convert():
                                 print('SSR 格式错误: %s' % ssr_content)
                             password_and_params = parts[5]
                             password_and_params = re.split(
-                                '/\?', password_and_params)
+                                '/\\?', password_and_params)
                             password_encode_str = password_and_params[0]
                             params = password_and_params[1]
 
-                            param_parts = re.split('\&', params)
+                            param_parts = re.split('\\&', params)
                             param_dic = {'remarks': 'U1NSIE5vZGU=',
                                          'obfsparam': '', 'protoparam': '', 'group': ''}
                             for part in param_parts:
-                                key_and_value = re.split('\=', part)
+                                key_and_value = re.split('\\=', part)
                                 param_dic.update(
                                     {key_and_value[0]: key_and_value[1]})
                             yaml_url.setdefault(
@@ -565,7 +565,7 @@ class sub_convert():
                             server_part = part_list[0].replace('trojan://', '')
                             # 使用多个分隔符 https://blog.csdn.net/shidamowang/article/details/80254476 https://zhuanlan.zhihu.com/p/92287240
                             server_part_list = re.split(
-                                ':|@|\?|&', server_part)
+                                ':|@|\\?|&', server_part)
                             yaml_url.setdefault('server', server_part_list[1])
                             yaml_url.setdefault('port', server_part_list[2])
                             yaml_url.setdefault('type', 'trojan')


### PR DESCRIPTION
### Problem

Several regular-expression patterns in `utils/` are written as plain string literals with invalid escapes, so Python 3.12+ emits `SyntaxWarning: invalid escape sequence` at import time:

- `utils/list_merge.py` - `\|`
- `utils/list_merge_airport.py` - `\|`
- `utils/get_subs.py` - `\?` (x3)
- `utils/sub_convert.py` - `\?`, `\&`, `\=`

Since Python 3.12 these are `SyntaxWarning` (previously a silent `DeprecationWarning`) and are slated to become a `SyntaxError`. The daily aggregation workflow runs on Python 3.11 today and will hit these once the runner moves to 3.12+.

### Fix

Escape the backslashes so each pattern's string value is byte-for-byte identical (mirrors ruff's W605 autofix). The compiled regexes are unchanged.

### Verification

```
$ python3 -W error -c "import py_compile; py_compile.compile(f, doraise=True)"  # each changed file
# clean after; SyntaxWarning->error before
```

Each module's AST is unchanged (verified with `ast.dump` before/after).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014HBQNzAf5C2E3MiJC48HQw
